### PR TITLE
Updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Console.WriteLine($"Me: {me.DisplayName}, {me.UserPrincipalName}");
 
 ```csharp
 var users = await gcDeviceCode.Users.Request()
-.Top(5)
-.Select(u => new {u.DisplayName, u.UserPrincipalName})
-.GetAsync();
+    .Top(5)
+    .Select(u => new {u.DisplayName, u.UserPrincipalName})
+    .GetAsync();
 
 users.Select(u => new {u.DisplayName, u.UserPrincipalName})
 ```
@@ -63,11 +63,11 @@ new QueryOption("$count", "true")
 };
 
 var applications = await gcClientCredential.Applications
-.Request( queryOptions )
-.Header("ConsistencyLevel","eventual")
-.Top(5)
-.Select(a => new {a.AppId, a.DisplayName})
-.GetAsync();
+    .Request( queryOptions )
+    .Header("ConsistencyLevel","eventual")
+    .Top(5)
+    .Select(a => new {a.AppId, a.DisplayName})
+    .GetAsync();
 
 applications.Select(a => new {a.AppId, a.DisplayName})
 ```

--- a/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
+++ b/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
@@ -22,10 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.7.0" />
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22504.6" />
-    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22504.6" />
-    <PackageReference Include="Microsoft.Graph" Version="4.46.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.0" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22553.7" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22553.7" />
+    <PackageReference Include="Microsoft.Graph" Version="4.47.0" />
     <PackageReference Include="MinVer" Version="4.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Dependabot failed to update the Microsoft.Dotnet.Interactive libraries because they both need to be updated at the same time.

Also updated the other deps while I was in there.