### PR TITLE
Added parameter validation + .NET 6 features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ bld/
 *.cer
 
 # Settings JSON file
-appregistration.json
+*appregistration.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "cref",
         "MSRC"
     ],
     "editor.formatOnType": true

--- a/src/ApiVersion.cs
+++ b/src/ApiVersion.cs
@@ -1,21 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
+
+/// <summary>
+/// Microsoft Graph API versions.
+/// </summary>
+public enum ApiVersion
 {
     /// <summary>
-    /// Microsoft Graph API versions.
+    /// Microsoft Graph V1 version.
     /// </summary>
-    public enum ApiVersion
-    {
-        /// <summary>
-        /// Microsoft Graph V1 version.
-        /// </summary>
-        V1,
+    V1,
 
-        /// <summary>
-        /// Microsoft Graph Beta version.
-        /// </summary>
-        Beta,
-    }
+    /// <summary>
+    /// Microsoft Graph Beta version.
+    /// </summary>
+    Beta,
 }

--- a/src/AuthenticationFlow.cs
+++ b/src/AuthenticationFlow.cs
@@ -1,26 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
+
+/// <summary>
+/// Supported authentication flows.
+/// </summary>
+public enum AuthenticationFlow
 {
     /// <summary>
-    /// Supported authentication flows.
+    /// App-only authentication with client secret.
     /// </summary>
-    public enum AuthenticationFlow
-    {
-        /// <summary>
-        /// App-only authentication with client secret.
-        /// </summary>
-        ClientCredential,
+    ClientCredential,
 
-        /// <summary>
-        /// User authentication with device code flow.
-        /// </summary>
-        DeviceCode,
+    /// <summary>
+    /// User authentication with device code flow.
+    /// </summary>
+    DeviceCode,
 
-        /// <summary>
-        /// User authentication via system default browser.
-        /// </summary>
-        InteractiveBrowser,
-    }
+    /// <summary>
+    /// User authentication via system default browser.
+    /// </summary>
+    InteractiveBrowser,
 }

--- a/src/BaseUrl.cs
+++ b/src/BaseUrl.cs
@@ -1,35 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
 
-namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+/// <summary>
+/// Helper class to set BaseUrl for Microsoft Graph service root endpoint.
+/// </summary>
+public class BaseUrl
 {
     /// <summary>
-    /// Helper class to set BaseUrl for Microsoft Graph service root endpoint.
+    /// Gets the BaseUrl for Microsoft Graph service root endpoint based on national cloud and API version.
     /// </summary>
-    public class BaseUrl
-    {
-        /// <summary>
-        /// Gets the BaseUrl for Microsoft Graph service root endpoint based on national cloud and API version.
-        /// </summary>
-        /// <param name="nationalCloud">The national cloud for Microsoft Graph service root endpoint.</param>
-        /// <param name="apiVersion">The API version for Microsoft Graph service root endpoint.</param>
-        /// <returns>The requested BaseUrl for Microsoft Graph service root endpoint.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">The requested national cloud and API Version pair was invalid.</exception>
-        public static string GetBaseUrl(
-            NationalCloud nationalCloud, ApiVersion apiVersion) => (nationalCloud, apiVersion) switch
-            {
-                (NationalCloud.Global, ApiVersion.V1) => new string("https://graph.microsoft.com/v1.0"),
-                (NationalCloud.Global, ApiVersion.Beta) => new string("https://graph.microsoft.com/beta"),
-                (NationalCloud.USGov, ApiVersion.V1) => new string("https://graph.microsoft.us/v1.0"),
-                (NationalCloud.USGov, ApiVersion.Beta) => new string("https://graph.microsoft.us/beta"),
-                (NationalCloud.USGovDoD, ApiVersion.V1) => new string("https://dod-graph.microsoft.us/v1.0"),
-                (NationalCloud.USGovDoD, ApiVersion.Beta) => new string("https://dod-graph.microsoft.us/beta"),
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(nationalCloud),
-                    nameof(apiVersion),
-                    $"Unexpected nationalCloud and apiVersion pair values: {nationalCloud}, {apiVersion}"),
-            };
-    }
+    /// <param name="nationalCloud">The national cloud for Microsoft Graph service root endpoint.</param>
+    /// <param name="apiVersion">The API version for Microsoft Graph service root endpoint.</param>
+    /// <returns>The requested BaseUrl for Microsoft Graph service root endpoint.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The requested national cloud and API Version pair was invalid.</exception>
+    public static string GetBaseUrl(
+        NationalCloud nationalCloud, ApiVersion apiVersion) => (nationalCloud, apiVersion) switch
+        {
+            (NationalCloud.Global, ApiVersion.V1) => new string("https://graph.microsoft.com/v1.0"),
+            (NationalCloud.Global, ApiVersion.Beta) => new string("https://graph.microsoft.com/beta"),
+            (NationalCloud.USGov, ApiVersion.V1) => new string("https://graph.microsoft.us/v1.0"),
+            (NationalCloud.USGov, ApiVersion.Beta) => new string("https://graph.microsoft.us/beta"),
+            (NationalCloud.USGovDoD, ApiVersion.V1) => new string("https://dod-graph.microsoft.us/v1.0"),
+            (NationalCloud.USGovDoD, ApiVersion.Beta) => new string("https://dod-graph.microsoft.us/beta"),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(nationalCloud),
+                nameof(apiVersion),
+                $"Unexpected nationalCloud and apiVersion pair values: {nationalCloud}, {apiVersion}"),
+        };
 }

--- a/src/CredentialOptions.cs
+++ b/src/CredentialOptions.cs
@@ -41,25 +41,72 @@ public class CredentialOptions
     /// <param name="clientId">The client ID parameter from the magic command.</param>
     /// <param name="clientSecret">The client secret parameter from the magic command.</param>
     /// <param name="configFile">The configuration file parameter from the magic command.</param>
+    /// <param name="tenantIdIsDefault">True if the value of tenantId is the default value.</param>
     /// <returns>The determined options.</returns>
     /// <exception cref="ArgumentException">Thrown if a configuration file is specified but does not exist.</exception>
-    public static CredentialOptions GetCredentialOptions(string tenantId, string clientId, string? clientSecret, string? configFile)
+    public static CredentialOptions GetCredentialOptions(string? tenantId, string? clientId, string? clientSecret, FileInfo? configFile, bool tenantIdIsDefault)
     {
         CredentialOptions? options = null;
 
-        if (!string.IsNullOrEmpty(configFile))
+        if (configFile != null)
         {
-            var configFileStream = File.OpenRead(configFile);
+            var configFileStream = configFile.OpenRead();
             options = JsonSerializer.Deserialize<CredentialOptions>(configFileStream, jsonOptions);
         }
 
         options = options ?? new CredentialOptions();
 
         // Passed parameters take precedence
-        options.ClientId = string.IsNullOrEmpty(clientId) ? options.ClientId : clientId;
-        options.ClientSecret = string.IsNullOrEmpty(clientSecret) ? options.ClientSecret : clientSecret;
-        options.TenantId = string.IsNullOrEmpty(tenantId) ? options.TenantId : tenantId;
+        options.ClientId = string.IsNullOrWhiteSpace(clientId) ? options.ClientId : clientId;
+        options.ClientSecret = string.IsNullOrWhiteSpace(clientSecret) ? options.ClientSecret : clientSecret;
+
+        // Tenant ID has a default value "common"
+        if (string.IsNullOrEmpty(tenantId) || tenantIdIsDefault)
+        {
+            tenantId = tenantId ?? string.Empty;
+
+            // If the tenant ID from the parser is the default value, only use it if
+            // there isn't a value in the config file
+            options.TenantId = string.IsNullOrWhiteSpace(options.TenantId) ? tenantId : options.TenantId;
+        }
+        else
+        {
+            // If it is not the default value, then it wins
+            options.TenantId = tenantId;
+        }
 
         return options;
+    }
+
+    /// <summary>
+    /// Validates that the required values are present for the requested authentication flow.
+    /// </summary>
+    /// <param name="authenticationFlow">The requested authentication flow.</param>
+    /// <exception cref="AggregateException">Thrown if there are any validation errors.</exception>
+    public void ValidateOptionsForFlow(AuthenticationFlow authenticationFlow)
+    {
+        List<Exception> exceptions = new();
+
+        // There must be a client ID for all flows
+        if (string.IsNullOrWhiteSpace(this.ClientId))
+        {
+            exceptions.Add(
+                new ArgumentException(
+                    "A client ID must be provided in the --client-id parameter or inside the JSON file provided with the --config-file parameter."));
+        }
+
+        // There must be a client secret if using client credentials flow
+        if (authenticationFlow == AuthenticationFlow.ClientCredential &&
+            string.IsNullOrWhiteSpace(this.ClientSecret))
+        {
+            exceptions.Add(
+                new ArgumentException(
+                    "A client secret must be provided in the --client-secret parameter or inside the JSON file provided with the --config-file parameter."));
+        }
+
+        if (exceptions.Any())
+        {
+            throw new AggregateException("One or more required values are missing.", exceptions);
+        }
     }
 }

--- a/src/CredentialOptions.cs
+++ b/src/CredentialOptions.cs
@@ -1,70 +1,65 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.IO;
 using System.Text.Json;
 
-namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
+
+/// <summary>
+/// Helper class to determine app registration options
+/// based on passed parameters.
+/// </summary>
+public class CredentialOptions
 {
-    /// <summary>
-    /// Helper class to determine app registration options
-    /// based on passed parameters.
-    /// </summary>
-    public class CredentialOptions
+    private static JsonSerializerOptions jsonOptions = new JsonSerializerOptions
     {
-        private static JsonSerializerOptions jsonOptions = new JsonSerializerOptions
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>
+    /// Gets or sets the client ID registered in the Azure portal.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the client secret registered in the Azure portal.
+    /// </summary>
+    public string ClientSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the tenant ID from the Azure portal.
+    /// </summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Loads the configuration file (if applicable) and combines its values
+    /// with the explicit parameters. Explicit parameters override values in
+    /// the configuration file.
+    /// </summary>
+    /// <param name="tenantId">The tenant ID parameter from the magic command.</param>
+    /// <param name="clientId">The client ID parameter from the magic command.</param>
+    /// <param name="clientSecret">The client secret parameter from the magic command.</param>
+    /// <param name="configFile">The configuration file parameter from the magic command.</param>
+    /// <returns>The determined options.</returns>
+    /// <exception cref="ArgumentException">Thrown if a configuration file is specified but does not exist.</exception>
+    public static CredentialOptions GetCredentialOptions(string tenantId, string clientId, string? clientSecret, string? configFile)
+    {
+        CredentialOptions? options = null;
+
+        if (!string.IsNullOrEmpty(configFile))
         {
-            PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
-
-        /// <summary>
-        /// Gets or sets the client ID registered in the Azure portal.
-        /// </summary>
-        public string ClientId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the client secret registered in the Azure portal.
-        /// </summary>
-        public string ClientSecret { get; set; }
-
-        /// <summary>
-        /// Gets or sets the tenant ID from the Azure portal.
-        /// </summary>
-        public string TenantId { get; set; }
-
-        /// <summary>
-        /// Loads the configuration file (if applicable) and combines its values
-        /// with the explicit parameters. Explicit parameters override values in
-        /// the configuration file.
-        /// </summary>
-        /// <param name="tenantId">The tenant ID parameter from the magic command.</param>
-        /// <param name="clientId">The client ID parameter from the magic command.</param>
-        /// <param name="clientSecret">The client secret parameter from the magic command.</param>
-        /// <param name="configFile">The configuration file parameter from the magic command.</param>
-        /// <returns>The determined options.</returns>
-        /// <exception cref="ArgumentException">Thrown if a configuration file is specified but does not exist.</exception>
-        public static CredentialOptions GetCredentialOptions(string tenantId, string clientId, string clientSecret, string configFile)
-        {
-            CredentialOptions options = null;
-
-            if (string.IsNullOrEmpty(configFile))
-            {
-                options = new CredentialOptions();
-            }
-            else
-            {
-                var configFileStream = File.OpenRead(configFile);
-                options = JsonSerializer.Deserialize<CredentialOptions>(configFileStream, jsonOptions);
-            }
-
-            // Passed parameters take precedence
-            options.ClientId = string.IsNullOrEmpty(clientId) ? options.ClientId : clientId;
-            options.ClientSecret = string.IsNullOrEmpty(clientSecret) ? options.ClientSecret : clientSecret;
-            options.TenantId = string.IsNullOrEmpty(tenantId) ? options.TenantId : tenantId;
-
-            return options;
+            var configFileStream = File.OpenRead(configFile);
+            options = JsonSerializer.Deserialize<CredentialOptions>(configFileStream, jsonOptions);
         }
+
+        options = options ?? new CredentialOptions();
+
+        // Passed parameters take precedence
+        options.ClientId = string.IsNullOrEmpty(clientId) ? options.ClientId : clientId;
+        options.ClientSecret = string.IsNullOrEmpty(clientSecret) ? options.ClientSecret : clientSecret;
+        options.TenantId = string.IsNullOrEmpty(tenantId) ? options.TenantId : tenantId;
+
+        return options;
     }
 }

--- a/src/CredentialOptionsBinder.cs
+++ b/src/CredentialOptionsBinder.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Binding;
+
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
+
+/// <summary>
+/// Binder class to combine command line parameters with a configuration file to produce a
+/// CredentialOptions object.
+/// </summary>
+public class CredentialOptionsBinder : BinderBase<CredentialOptions>
+{
+    private readonly Option<string?> clientIdOption;
+    private readonly Option<string> tenantIdOption;
+    private readonly Option<string?> clientSecretOption;
+    private readonly Option<FileInfo> configFileOption;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CredentialOptionsBinder"/> class.
+    /// </summary>
+    /// <param name="clientIdOption">The <see cref="Option"/> that provides the client ID.</param>
+    /// <param name="tenantIdOption">The <see cref="Option"/> that provides the tenant ID.</param>
+    /// <param name="clientSecretOption">The <see cref="Option"/> that provides the client secret.</param>
+    /// <param name="configFileOption">The <see cref="Option"/> that provides the config file.</param>
+    public CredentialOptionsBinder(Option<string?> clientIdOption, Option<string> tenantIdOption, Option<string?> clientSecretOption, Option<FileInfo> configFileOption)
+    {
+        this.clientIdOption = clientIdOption;
+        this.tenantIdOption = tenantIdOption;
+        this.clientSecretOption = clientSecretOption;
+        this.configFileOption = configFileOption;
+    }
+
+    /// <summary>
+    /// Combines values from the command line with values from the config file to create
+    /// an instance of the <see cref="CredentialOptions"/> class.
+    /// </summary>
+    /// <param name="bindingContext">The binding context that contains the required values.</param>
+    /// <returns>The <see cref="CredentialOptions"/> containing the combined values.</returns>
+    protected override CredentialOptions GetBoundValue(BindingContext bindingContext)
+    {
+        var tenantIdIsDefaultValue = bindingContext.ParseResult.FindResultFor(this.tenantIdOption)?.IsImplicit ?? true;
+
+        var clientId = bindingContext.ParseResult.GetValueForOption(this.clientIdOption);
+        var tenantId = bindingContext.ParseResult.GetValueForOption(this.tenantIdOption);
+        var clientSecret = bindingContext.ParseResult.GetValueForOption(this.clientSecretOption);
+        var configFile = bindingContext.ParseResult.GetValueForOption(this.configFileOption);
+
+        return CredentialOptions.GetCredentialOptions(tenantId, clientId, clientSecret, configFile, tenantIdIsDefaultValue);
+    }
+}

--- a/src/CredentialProvider.cs
+++ b/src/CredentialProvider.cs
@@ -1,96 +1,92 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 
-namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
+
+/// <summary>
+/// Helper class to create an appropriate TokenCredential
+/// based on the requested authentication flow.
+/// </summary>
+public class CredentialProvider
 {
     /// <summary>
-    /// Helper class to create an appropriate TokenCredential
-    /// based on the requested authentication flow.
+    /// Gets the TokenCredential based on the requested authentication flow.
     /// </summary>
-    public class CredentialProvider
+    /// <param name="authenticationFlow">The requested authentication flow.</param>
+    /// <param name="credentialOptions">The client ID, client secret, and tenant ID from the app registration in Azure portal.</param>
+    /// <param name="nationalCloud">The national cloud for authentication and Microsoft Graph service root endpoint.</param>
+    /// <returns>The requested TokenCredential.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The requested authentication flow was invalid.</exception>
+    public static TokenCredential GetTokenCredential(
+        AuthenticationFlow authenticationFlow,
+        CredentialOptions credentialOptions,
+        NationalCloud nationalCloud) => authenticationFlow switch
+        {
+            AuthenticationFlow.ClientCredential => GetClientSecretCredential(credentialOptions.TenantId, credentialOptions.ClientId, credentialOptions.ClientSecret, nationalCloud),
+            AuthenticationFlow.DeviceCode => GetDeviceCodeCredential(credentialOptions.TenantId, credentialOptions.ClientId, nationalCloud),
+            AuthenticationFlow.InteractiveBrowser => GetInteractiveBrowserCredential(credentialOptions.TenantId, credentialOptions.ClientId, nationalCloud),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(authenticationFlow),
+                $"Unexpected authenticationFlow value: {authenticationFlow}"),
+        };
+
+    /// <summary>
+    /// Gets the Uri for Azure Authority Host based on the nationalCloud.
+    /// </summary>
+    /// <param name="nationalCloud">The national cloud for authentication and Microsoft Graph service root endpoint.</param>
+    /// <returns>The requested Uri for Azure Authority Host.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The requested national cloud was invalid.</exception>
+    public static Uri GetAuthorityHosts(
+        NationalCloud nationalCloud) => nationalCloud switch
+        {
+            NationalCloud.Global => AzureAuthorityHosts.AzurePublicCloud,
+            NationalCloud.USGov => AzureAuthorityHosts.AzureGovernment,
+            NationalCloud.USGovDoD => AzureAuthorityHosts.AzureGovernment,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(nationalCloud),
+                $"Unexpected nationalCloud value: {nationalCloud}"),
+        };
+
+    private static ClientSecretCredential GetClientSecretCredential(
+        string tenantId, string clientId, string clientSecret, NationalCloud nationalCloud)
     {
-        /// <summary>
-        /// Gets the TokenCredential based on the requested authentication flow.
-        /// </summary>
-        /// <param name="authenticationFlow">The requested authentication flow.</param>
-        /// <param name="credentialOptions">The client ID, client secret, and tenant ID from the app registration in Azure portal.</param>
-        /// <param name="nationalCloud">The national cloud for authentication and Microsoft Graph service root endpoint.</param>
-        /// <returns>The requested TokenCredential.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">The requested authentication flow was invalid.</exception>
-        public static TokenCredential GetTokenCredential(
-            AuthenticationFlow authenticationFlow,
-            CredentialOptions credentialOptions,
-            NationalCloud nationalCloud) => authenticationFlow switch
-            {
-                AuthenticationFlow.ClientCredential => GetClientSecretCredential(credentialOptions.TenantId, credentialOptions.ClientId, credentialOptions.ClientSecret, nationalCloud),
-                AuthenticationFlow.DeviceCode => GetDeviceCodeCredential(credentialOptions.TenantId, credentialOptions.ClientId, nationalCloud),
-                AuthenticationFlow.InteractiveBrowser => GetInteractiveBrowserCredential(credentialOptions.TenantId, credentialOptions.ClientId, nationalCloud),
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(authenticationFlow),
-                    $"Unexpected authenticationFlow value: {authenticationFlow}"),
-            };
-
-        /// <summary>
-        /// Gets the Uri for Azure Authority Host based on the nationalCloud.
-        /// </summary>
-        /// <param name="nationalCloud">The national cloud for authentication and Microsoft Graph service root endpoint.</param>
-        /// <returns>The requested Uri for Azure Authority Host.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">The requested national cloud was invalid.</exception>
-        public static Uri GetAuthorityHosts(
-            NationalCloud nationalCloud) => nationalCloud switch
-            {
-                NationalCloud.Global => AzureAuthorityHosts.AzurePublicCloud,
-                NationalCloud.USGov => AzureAuthorityHosts.AzureGovernment,
-                NationalCloud.USGovDoD => AzureAuthorityHosts.AzureGovernment,
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(nationalCloud),
-                    $"Unexpected nationalCloud value: {nationalCloud}"),
-            };
-
-        private static ClientSecretCredential GetClientSecretCredential(
-            string tenantId, string clientId, string clientSecret, NationalCloud nationalCloud)
+        var options = new TokenCredentialOptions
         {
-            var options = new TokenCredentialOptions
-            {
-                AuthorityHost = GetAuthorityHosts(nationalCloud),
-            };
+            AuthorityHost = GetAuthorityHosts(nationalCloud),
+        };
 
-            return new ClientSecretCredential(tenantId, clientId, clientSecret, options);
-        }
+        return new ClientSecretCredential(tenantId, clientId, clientSecret, options);
+    }
 
-        private static DeviceCodeCredential GetDeviceCodeCredential(
-            string tenantId, string clientId, NationalCloud nationalCloud)
+    private static DeviceCodeCredential GetDeviceCodeCredential(
+        string tenantId, string clientId, NationalCloud nationalCloud)
+    {
+        var options = new TokenCredentialOptions
         {
-            var options = new TokenCredentialOptions
-            {
-                AuthorityHost = GetAuthorityHosts(nationalCloud),
-            };
+            AuthorityHost = GetAuthorityHosts(nationalCloud),
+        };
 
-            Func<DeviceCodeInfo, CancellationToken, Task> callback = (code, cancellation) =>
-            {
-                Console.WriteLine(code.Message);
-                return Task.FromResult(0);
-            };
-
-            return new DeviceCodeCredential(callback, tenantId, clientId, options);
-        }
-
-        private static InteractiveBrowserCredential GetInteractiveBrowserCredential(
-            string tenantId, string clientId, NationalCloud nationalCloud)
+        Func<DeviceCodeInfo, CancellationToken, Task> callback = (code, cancellation) =>
         {
-            var options = new InteractiveBrowserCredentialOptions
-            {
-                AuthorityHost = GetAuthorityHosts(nationalCloud),
-                RedirectUri = new Uri("http://localhost"),
-            };
+            Console.WriteLine(code.Message);
+            return Task.FromResult(0);
+        };
 
-            return new InteractiveBrowserCredential(tenantId, clientId, options);
-        }
+        return new DeviceCodeCredential(callback, tenantId, clientId, options);
+    }
+
+    private static InteractiveBrowserCredential GetInteractiveBrowserCredential(
+        string tenantId, string clientId, NationalCloud nationalCloud)
+    {
+        var options = new InteractiveBrowserCredentialOptions
+        {
+            AuthorityHost = GetAuthorityHosts(nationalCloud),
+            RedirectUri = new Uri("http://localhost"),
+        };
+
+        return new InteractiveBrowserCredential(tenantId, clientId, options);
     }
 }

--- a/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
+++ b/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/NationalCloud.cs
+++ b/src/NationalCloud.cs
@@ -1,26 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
+
+/// <summary>
+/// Supported national clouds.
+/// </summary>
+public enum NationalCloud
 {
     /// <summary>
-    /// Supported national clouds.
+    /// Microsoft Graph global service.
     /// </summary>
-    public enum NationalCloud
-    {
-        /// <summary>
-        /// Microsoft Graph global service.
-        /// </summary>
-        Global,
+    Global,
 
-        /// <summary>
-        /// Microsoft Graph for US Government L4.
-        /// </summary>
-        USGov,
+    /// <summary>
+    /// Microsoft Graph for US Government L4.
+    /// </summary>
+    USGov,
 
-        /// <summary>
-        /// Microsoft Graph for US Government L5 (DOD).
-        /// </summary>
-        USGovDoD,
-    }
+    /// <summary>
+    /// Microsoft Graph for US Government L5 (DOD).
+    /// </summary>
+    USGovDoD,
 }

--- a/src/Scopes.cs
+++ b/src/Scopes.cs
@@ -1,30 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
+namespace Microsoft.DotNet.Interactive.MicrosoftGraph;
 
-namespace Microsoft.DotNet.Interactive.MicrosoftGraph
+/// <summary>
+/// Helper class to set scopes for authentication based on national cloud.
+/// </summary>
+public class Scopes
 {
     /// <summary>
-    /// Helper class to set scopes for authentication based on national cloud.
+    /// Gets the Uri for Azure Authority Host based on the nationalCloud.
     /// </summary>
-    public class Scopes
-    {
-        /// <summary>
-        /// Gets the Uri for Azure Authority Host based on the nationalCloud.
-        /// </summary>
-        /// <param name="nationalCloud">The national cloud for authentication and Microsoft Graph service root endpoint.</param>
-        /// <returns>The requested Uri for Azure Authority Host.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">The requested national cloud was invalid.</exception>
-        public static string[] GetScopes(
-            NationalCloud nationalCloud) => nationalCloud switch
-            {
-                NationalCloud.Global => new string[] { "https://graph.microsoft.com/.default" },
-                NationalCloud.USGov => new string[] { "https://graph.microsoft.us/.default" },
-                NationalCloud.USGovDoD => new string[] { "https://dod-graph.microsoft.us/.default" },
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(nationalCloud),
-                    $"Unexpected nationalCloud value: {nationalCloud}"),
-            };
-    }
+    /// <param name="nationalCloud">The national cloud for authentication and Microsoft Graph service root endpoint.</param>
+    /// <returns>The requested Uri for Azure Authority Host.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The requested national cloud was invalid.</exception>
+    public static string[] GetScopes(
+        NationalCloud nationalCloud) => nationalCloud switch
+        {
+            NationalCloud.Global => new string[] { "https://graph.microsoft.com/.default" },
+            NationalCloud.USGov => new string[] { "https://graph.microsoft.us/.default" },
+            NationalCloud.USGovDoD => new string[] { "https://dod-graph.microsoft.us/.default" },
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(nationalCloud),
+                $"Unexpected nationalCloud value: {nationalCloud}"),
+        };
 }


### PR DESCRIPTION
While attempting to add validation on parameters like client ID, secret, etc., I realized that because those values could be either in a parameter OR in the config file, you couldn't just throw an error if a parameter was missing.

To solve this, I created a custom binder. This allows our command handler to just take an instance of the CredentialsOptions class that is built from the appropriate combo of command line parameters and values in the config file. The binder takes care of which value takes precedence.

I added a ValidateOptionsForFlow method to the CredentialOptions class that throws an exception if the options aren't valid, based on which auth flow is requested. For example, a client secret is required for client credentials, but not for others.

Additional changes:
- Enabled nullable and marked optional parameters with no defaults as nullable
- Enabled implicit usings and removed unnecessary using statements
- Made all namespace declarations file-level