### PR TITLE
Update to .Net 7 target framework

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
+++ b/src/Microsoft.DotNet.Interactive.MicrosoftGraph.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IncludeBuildOutput>true</IncludeBuildOutput>


### PR DESCRIPTION
Update target framework from .Net 6 to .Net 7 as Polyglot Notebooks is now requiring .Net 7.